### PR TITLE
Add an option to pass a custom RuTracker URL

### DIFF
--- a/src/RuTracker.Client/ApiUtil.cs
+++ b/src/RuTracker.Client/ApiUtil.cs
@@ -9,7 +9,7 @@ namespace RuTracker.Client
 {
     static class ApiUtil
     {
-        public static readonly Uri BaseUri = new("https://rutracker.org/");
+        public static Uri BaseUri = new("https://rutracker.org/");
 
         static void AddSession(HttpRequestMessage req, string session)
         {

--- a/src/RuTracker.Client/RuTrackerAuthClient.cs
+++ b/src/RuTracker.Client/RuTrackerAuthClient.cs
@@ -10,9 +10,14 @@ namespace RuTracker.Client
     {
         readonly HttpClient _httpClient;
 
-        public RuTrackerAuthClient(HttpClient httpClient) => _httpClient = httpClient;
-        public RuTrackerAuthClient()
+        public RuTrackerAuthClient(HttpClient httpClient, string ruTrackerBaseUrl = "https://rutracker.org/")
         {
+            _httpClient = httpClient;
+            ApiUtil.BaseUri = new Uri(ruTrackerBaseUrl);
+        }
+        public RuTrackerAuthClient(string ruTrackerBaseUrl = "https://rutracker.org/")
+        {
+            ApiUtil.BaseUri = new Uri(ruTrackerBaseUrl);
             var httpClientHandler = new HttpClientHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip,


### PR DESCRIPTION
I suggest we have this option to use a custom RuTracker URL. There are many mirrors which work for different countries, but current version of the package only supports the main URL.